### PR TITLE
Make log message less scary.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -202,7 +202,8 @@ struct CmdLineArgs {
 
 	while (getline(is, s, ',')) {
 	    taskReject.insert(taskhandle_t(ator(s.c_str())));
-	    syslog(LOG_NOTICE, "rejecting requests to task '%s'", s.c_str());
+	    syslog(LOG_NOTICE, "blocking '%s' requests from TCP clients",
+		   s.c_str());
 	}
     }
 


### PR DESCRIPTION
The log message reporting the handles that are blocked for TCP clients wasn't worded very well. It made it sound like there was a problem rather than reporting the configuration parameters.