### PR TITLE
Fix: :bug: Permissions in workflow to release

### DIFF
--- a/.github/workflows/cvs-patch.yaml
+++ b/.github/workflows/cvs-patch.yaml
@@ -17,12 +17,6 @@ jobs:
         with:
           fetch-depth: 0 # Checkout all commits
 
-      - name: Debug - Print ACTION_RELEASES_APP_ID (Before Set up Git)
-        run: |
-          echo "Debugging ACTION_RELEASES_APP_ID:"
-          echo "vars.ACTION_RELEASES_APP_ID: ${{ vars.ACTION_RELEASES_APP_ID }}"
-        shell: /usr/bin/bash -e {0}
-
       - name: Set up Git identity
         run: |
           git config --local user.name "GitHub Actions"
@@ -68,13 +62,6 @@ jobs:
           fi
         shell: /usr/bin/bash -e {0} # Use bash instead of sh
 
-      - name: Debug - Print ACTION_RELEASES_APP_ID (Before Generate Token)
-        if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }}
-        run: |
-          echo "Debugging ACTION_RELEASES_APP_ID (Before Generate Token):"
-          echo "vars.ACTION_RELEASES_APP_ID: ${{ vars.ACTION_RELEASES_APP_ID }}"
-        shell: /usr/bin/bash -e {0}
-
       - name: Generate a token
         if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }} # Conditional release creation
         id: generate-token
@@ -82,15 +69,6 @@ jobs:
         with:
           app-id: ${{ vars.ACTION_RELEASES_APP_ID }}
           private-key: ${{ secrets.ACTION_RELEASES_PRIVATE_KEY }}
-
-      - name: Debug - Print ACTION_RELEASES_APP_ID (After Generate Token)
-        if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }}
-        run: |
-          echo "Debugging ACTION_RELEASES_APP_ID (After Generate Token):"
-          echo "vars.ACTION_RELEASES_APP_ID: ${{ vars.ACTION_RELEASES_APP_ID }}"
-          echo "Token generation step result: ${{ steps.generate-token.outcome }}"
-          echo "Token output: ${{ steps.generate-token.outputs.token }}" # Be cautious printing tokens in full logs in production
-        shell: /usr/bin/bash -e {0}
 
       - name: Create GitHub Release
         if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }} # Conditional release creation
@@ -139,9 +117,6 @@ jobs:
           draft: false
           prerelease: false
           files: ${{ steps.generate-patch.outputs.patch_file_path }}
-
-      - name: Debug - Print ACTION_RELEASES_APP_ID (Before Create Release)
-        if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }}
         run: |
           echo "Debugging ACTION_RELEASES_APP_ID (Before Create Release):"
           echo "vars.ACTION_RELEASES_APP_ID: ${{ vars.ACTION_RELEASES_APP_ID }}"

--- a/.github/workflows/cvs-patch.yaml
+++ b/.github/workflows/cvs-patch.yaml
@@ -62,20 +62,12 @@ jobs:
           fi
         shell: /usr/bin/bash -e {0} # Use bash instead of sh
 
-      - name: Generate a token
-        if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }} # Conditional release creation
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.ACTION_RELEASES_APP_ID }}
-          private-key: ${{ secrets.ACTION_RELEASES_PRIVATE_KEY }}
-
       - name: Create GitHub Release
         if: ${{ steps.generate-patch.outputs.patch_generated == 'true' }} # Conditional release creation
         id: create-release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: cvs-sync-release-${{ github.run_id }}
           name: CVS Patch Release - Commit ${{ steps.generate-patch.outputs.head_commit_short }}
@@ -117,7 +109,3 @@ jobs:
           draft: false
           prerelease: false
           files: ${{ steps.generate-patch.outputs.patch_file_path }}
-        run: |
-          echo "Debugging ACTION_RELEASES_APP_ID (Before Create Release):"
-          echo "vars.ACTION_RELEASES_APP_ID: ${{ vars.ACTION_RELEASES_APP_ID }}"
-        shell: /usr/bin/bash -e {0}


### PR DESCRIPTION
I was using the wrong token for the release.
Now we're using the default token because all we need is a GitHub release.