### PR TITLE
Fix: pin release target_commitish to commit SHA for cvs-sync.sh

### DIFF
--- a/.github/workflows/cvs-patch.yaml
+++ b/.github/workflows/cvs-patch.yaml
@@ -70,6 +70,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: cvs-sync-release-${{ github.run_id }}
+          # Pin the release to the exact commit this patch was generated from.
+          # Without this, GitHub defaults target_commitish to the branch name
+          # ("main"), and cvs-sync.sh reads target_commitish as the commit SHA
+          # to embed in the CVS commit message and `cvs tag git-hash-<sha>`.
+          # Leaving it unset causes every CVS sync to tag "git-hash-main"
+          # instead of a real commit hash, silently breaking the tag-based
+          # tracking the manual sync instructions below rely on.
+          target_commitish: ${{ github.sha }}
           name: CVS Patch Release - Commit ${{ steps.generate-patch.outputs.head_commit_short }}
           body: |
             ## Patch File Generated


### PR DESCRIPTION
## Problem

`cvs-sync.sh` (the script that consumes these releases on the CVS deployment side) reads the release's `target_commitish` field directly as the Git commit SHA:

```bash
GIT_COMMIT_SHA=$(echo "$LATEST_RELEASE_JSON" | jq -r '.target_commitish')
...
cvs commit -m "$CVS_COMMIT_MESSAGE - Release: $RELEASE_NAME ($RELEASE_TAG_NAME) - Git Commit: $GIT_COMMIT_SHA" .
...
CVS_TAG_NAME="${CVS_TAG_PREFIX}${GIT_COMMIT_SHA}"
cvs tag "$CVS_TAG_NAME"
```

But `.github/workflows/cvs-patch.yaml`'s `Create GitHub Release` step never sets `target_commitish` as an input to `softprops/action-gh-release@v2`. When left unset, GitHub does **not** default it to the commit the workflow ran on — it defaults to the **branch name** (`main`).

I verified this directly against this repo with a scratch draft release via the GitHub API (no `target_commitish` input):

```json
{"tag_name":"test-tmp-tag","target_commitish":"main", ...}
```

So today, every CVS sync run would compute `GIT_COMMIT_SHA="main"` and execute:

```
cvs tag git-hash-main
```

on every single release — never a real commit hash. This silently breaks the exact mechanism the release body's own instructions rely on ("Consult your CVS repository for the latest `git-hash-*` tag... apply the release for the commit *after* that hash"), since there would never be a distinct, valid `git-hash-<sha>` tag to look up.

This has not yet surfaced because every run of `cvs-patch.yaml` to date has failed before reaching the release step (see #15 fixing the crash in the patch-generation step).

## Fix

Explicitly pin `target_commitish` to `github.sha` (the commit the workflow is running for) on the release:

```yaml
target_commitish: ${{ github.sha }}
```

This is independent of and does not conflict with #15 (which only touches the `Generate patch file` step's `format-patch`/output logic). Recommend merging #15 first so this can be validated against a run that actually reaches the release-creation step.